### PR TITLE
feat(platform): add VCF annotation flow

### DIFF
--- a/autogpt_platform/backend/backend/server/routers/v1.py
+++ b/autogpt_platform/backend/backend/server/routers/v1.py
@@ -15,6 +15,7 @@ from typing_extensions import Optional, TypedDict
 
 import backend.server.integrations.router
 import backend.server.routers.analytics
+import backend.server.routers.vcf
 import backend.server.v2.library.db as library_db
 from backend.data import execution as execution_db
 from backend.data import graph as graph_db
@@ -113,6 +114,13 @@ v1_router.include_router(
     backend.server.routers.analytics.router,
     prefix="/analytics",
     tags=["analytics"],
+    dependencies=[Depends(auth_middleware)],
+)
+
+v1_router.include_router(
+    backend.server.routers.vcf.router,
+    prefix="/vcf",
+    tags=["vcf"],
     dependencies=[Depends(auth_middleware)],
 )
 

--- a/autogpt_platform/backend/backend/server/routers/vcf.py
+++ b/autogpt_platform/backend/backend/server/routers/vcf.py
@@ -1,0 +1,72 @@
+import logging
+from typing import Annotated, Dict, List
+
+import fastapi
+import httpx
+
+from backend.server.utils import get_user_id
+
+router = fastapi.APIRouter()
+logger = logging.getLogger(__name__)
+
+
+def _parse_info(info_str: str) -> Dict[str, str]:
+    result: Dict[str, str] = {}
+    for item in info_str.split(";"):
+        if not item:
+            continue
+        if "=" in item:
+            key, value = item.split("=", 1)
+            result[key] = value
+        else:
+            result[item] = ""
+    return result
+
+
+def _parse_vcf(content: str) -> List[Dict[str, object]]:
+    variants: List[Dict[str, object]] = []
+    header: List[str] = []
+    for line in content.splitlines():
+        if line.startswith("##"):
+            continue
+        if line.startswith("#"):
+            header = line.lstrip("#").split("\t")
+            continue
+        if not line.strip():
+            continue
+        fields = line.split("\t")
+        record = dict(zip(header, fields))
+        info_fields = _parse_info(record.get("INFO", ""))
+        record["INFO_PARSED"] = info_fields
+        fmt = record.get("FORMAT", "").split(":")
+        samples = fields[len(header) :]
+        record["SAMPLES"] = [dict(zip(fmt, s.split(":"))) for s in samples if s]
+        variants.append(record)
+    return variants
+
+
+async def _annotate_with_oncotator(content: str) -> str:
+    url = (
+        "https://portals.broadinstitute.org/oncotator/" "service/api/annotate/variants"
+    )
+    headers = {"Content-Type": "text/plain"}
+    try:
+        async with httpx.AsyncClient() as client:
+            resp = await client.post(url, content=content, headers=headers)
+            resp.raise_for_status()
+            return resp.text
+    except Exception as e:  # pragma: no cover - network operations
+        logger.exception("Oncotator annotation failed: %s", e)
+        raise fastapi.HTTPException(status_code=502, detail="Oncotator error")
+
+
+@router.post("/annotate")
+async def annotate_vcf(
+    file: fastapi.UploadFile,
+    user_id: Annotated[str, fastapi.Depends(get_user_id)],
+) -> Dict[str, object]:
+    content_bytes = await file.read()
+    content = content_bytes.decode("utf-8")
+    variants = _parse_vcf(content)
+    annotation = await _annotate_with_oncotator(content)
+    return {"variants": variants, "annotation": annotation}

--- a/autogpt_platform/frontend/src/app/(platform)/vcf/page.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/vcf/page.tsx
@@ -1,0 +1,41 @@
+"use client";
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { useBackendAPI } from "@/lib/autogpt-server-api/context";
+
+export default function VcfUploadPage() {
+  const [file, setFile] = useState<File | null>(null);
+  const [result, setResult] = useState<any>(null);
+  const api = useBackendAPI();
+
+  async function handleUpload() {
+    if (!file) return;
+    try {
+      const res = await api.annotateVcf(file);
+      setResult(res);
+    } catch (e) {
+      console.error(e);
+      setResult({ error: String(e) });
+    }
+  }
+
+  return (
+    <div className="container mx-auto max-w-2xl space-y-4 p-4">
+      <h1 className="text-2xl font-bold">VCF Annotation</h1>
+      <input
+        type="file"
+        accept=".vcf"
+        onChange={(e) => setFile(e.target.files?.[0] ?? null)}
+        className="block"
+      />
+      <Button onClick={handleUpload} disabled={!file} className="mt-2">
+        Upload
+      </Button>
+      {result && (
+        <pre className="overflow-auto whitespace-pre-wrap rounded bg-neutral-100 p-4 text-xs">
+          {JSON.stringify(result, null, 2)}
+        </pre>
+      )}
+    </div>
+  );
+}

--- a/autogpt_platform/frontend/src/lib/autogpt-server-api/client.ts
+++ b/autogpt_platform/frontend/src/lib/autogpt-server-api/client.ts
@@ -509,6 +509,16 @@ export default class BackendAPI {
     return this._uploadFile("/store/submissions/media", file);
   }
 
+  annotateVcf(file: File): Promise<any> {
+    return this._uploadFile("/vcf/annotate", file).then((t) => {
+      try {
+        return JSON.parse(t);
+      } catch {
+        return t;
+      }
+    });
+  }
+
   updateStoreProfile(profile: ProfileDetails): Promise<ProfileDetails> {
     return this._request("POST", "/store/profile", profile);
   }


### PR DESCRIPTION
## Changes
- enable uploading VCF files in the frontend
- add backend endpoint to parse VCF and call Oncotator
- expose `annotateVcf` helper in API client
- register new route in server

## Testing
- `pnpm format`
- `pnpm test`
- `poetry run format` *(failed: pyright errors)*
- `poetry run test` *(failed: docker not found)*

------
https://chatgpt.com/codex/tasks/task_e_68665b88ba64832dbab734f8944f9663